### PR TITLE
Seamless REST-based solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,110 @@
 # SpiraConfluence
 A SpiraApp for connecting Spira Requirements to Confluence documents
+
+**Version:** 0.2
+**Author:** [Dermot Canniffe/Inflectra Corporation]
+**Date:** May 11, 2025
+
+## Overview
+
+This SpiraApp enhances Spira Requirements by adding a dedicated "Confluence" button to the Requirement details page toolbar. This button provides a streamlined workflow for linking Spira Requirements to Confluence pages:
+
+1.  **Open Existing Link:** If a Confluence page URL is already present in a pre-configured custom field on the Requirement, clicking the button will open this URL directly in a new browser tab.
+2.  **Create New Page & Link:** If the configured custom field is empty or does not contain a valid URL:
+    * A new page will be created in a designated Confluence space via the Confluence API.
+    * This new Confluence page will automatically include a link back to the originating Spira Requirement (showing its name and ID).
+    * The URL of this newly created Confluence page will be populated into the configured custom field on the Spira Requirement form.
+    * The newly created Confluence page will then open in a new browser tab for immediate viewing or editing.
+    * **Crucial User Action:** After the link is populated into the Spira form, the user **must manually click Spira's main "Save" button** on the Requirement details page to persist this new Confluence link.
+
+## Setup Instructions
+
+Proper setup requires configuration at both the Spira System Administration level and the Product Administration level for each product intending to use this SpiraApp.
+
+### A. Spira System Administrator Steps:
+
+1.  **Install the SpiraApp:**
+    * Ensure "Developer Mode" is enabled in your Spira instance (System Admin > General Settings).
+    * Navigate to System Admin > Spira Apps.
+    * Upload the `.spiraapp` package file for this "Confluence Integration" SpiraApp.
+    * Once uploaded, enable the SpiraApp system-wide using the power toggle button in its row.
+2.  **Configure System-Wide Settings for the SpiraApp:**
+    * In the System Admin > Spira Apps list, click on the "Confluence Integration" SpiraApp name to access its settings.
+    * Configure the following system settings:
+        * **`confluenceBaseUrl` (Confluence Base URL):**
+            * **Description:** The root URL for your Confluence instance. This is used for API calls and constructing page links.
+            * **Example:** `https://your-company.atlassian.net`
+            * **Required:** Yes
+        * **`confluenceApiEmail` (Confluence API Email for Basic Auth):**
+            * **Description:** The email address associated with the Confluence API Token that will be used for authentication.
+            * **Example:** `your.email@example.com`
+            * **Required:** Yes (for Confluence API Basic Authentication)
+        * **`confluenceApiToken` (Confluence API Token / Password):**
+            * **Description:** The API token generated from Confluence. This is used as the password component for Basic Authentication with the Confluence API. This setting is stored securely by Spira.
+            * **Example:** (Enter your generated API token)
+            * **Required:** Yes
+
+### B. Spira Product Administrator Steps (Repeat for each Product):
+
+1.  **Enable the SpiraApp for the Product:**
+    * Navigate to the desired Spira Product.
+    * Go to Product Admin > General Settings > SpiraApps.
+    * Find the "Confluence Integration" SpiraApp in the list and enable it for the current product using its toggle switch.
+2.  * Create a Custom Field on Requirements Artifacts to contain the Confluence Page Link
+        * Make a note of the field identifier for this custom field (e.g. "Custom_10")    
+3.  **Configure Product-Specific Settings for the SpiraApp:**
+    * In Product Admin > General Settings > SpiraApps, click on the "Confluence Integration" SpiraApp name or its settings icon.
+    * Configure the following product settings:
+        * **`confluenceLinkFieldName` (Link Custom Field Name):**
+            * **Description:** The exact system name (e.g., `Custom_01`, `Custom_10`) of the Requirement custom property that will store and display the URL to the Confluence page. This custom property **must be of type "Text"**.
+            * **Example:** `Custom_10`
+            * **Required:** Yes
+        * **`confluenceSpaceKey` (Target Confluence Space Key):**
+            * **Description:** The unique key of the Confluence Space where new pages should be created if no existing link is found.
+            * **Example:** `MYPROJKEY`
+            * **Required:** Yes (for creating new pages)
+        * **`confluenceParentPageId` (Target Parent Page ID - Optional):**
+            * **Description:** If you want new Confluence pages to be created as children of a specific existing page in Confluence, enter that parent page's numerical ID here. If left blank, pages will be created at the root of the specified space.
+            * **Example:** `12345678` (or leave blank)
+            * **Required:** No
+
+## How to Use (End User Guide)
+
+Once configured by administrators:
+
+1.  Navigate to a Requirement details page within a Spira product where the "Confluence Integration" SpiraApp has been enabled and configured.
+2.  Locate and click the **"Confluence"** button in the toolbar (it typically displays with a Confluence logo icon).
+3.  The SpiraApp will then perform one of two actions:
+    * **If a valid Confluence URL already exists** in the custom field specified in the product settings (e.g., `Custom_10`): The existing Confluence page will immediately open in a new browser tab.
+    * **If the custom field is empty or does not contain a valid URL:**
+        1.  A message "Attempting to create page in Confluence..." may briefly appear.
+        2.  A new page will be created in the configured Confluence space.
+        3.  The URL of this new Confluence page will be automatically populated into the designated custom field on the current Spira Requirement form.
+        4.  A success message will appear: *"Confluence page created. Link has been populated into the '[YourCustomFieldName]' field on this form. Please click Spira's 'Save' button to persist this change."*
+        5.  The newly created Confluence page will open in a new browser tab.
+4.  **IMPORTANT (If a new page was created):** After the link is populated into the Spira Requirement form, you **MUST click Spira's main "Save" button** for that Requirement.
+    * *Usability Note:* You might need to first click into the custom field where the link was populated to ensure Spira's "Save" button becomes active. Then, click "Save".
+
+## Technical Notes & Development Journey (For Developers / Review)
+
+This version of the SpiraApp utilizes `spiraAppManager.updateFormField()` to populate the Confluence link into the Spira Requirement form. This requires the user to perform a manual save action via Spira's standard "Save" button to persist the change. This approach was adopted for its simplicity and alignment with typical SpiraApp UI interaction patterns.
+
+An earlier development iteration attempted to save the Confluence link back to the Spira Requirement automatically and silently using a direct Spira REST API `PUT` request to the `/projects/{projectId}/requirements` endpoint. This involved more complex client-side logic:
+* Fetching the `PropertyDefinitionId` for the target custom field (from the product template API).
+* Attempting to cache this `PropertyDefinitionId` in SpiraApp Product Level Storage (`spiraAppManager.storageGetProduct` and `storageInsertProduct`).
+* GETting the full Requirement data to obtain the `ConcurrencyDate` and other fields.
+* Constructing a complete and valid PUT payload, including the `ConcurrencyDate` and correctly formatted `CustomProperties` array.
+* Executing the PUT request using `spiraAppManager.executeApi`.
+* Attempting to refresh the form using `spiraAppManager.reloadForm()`.
+
+**Key Challenges Encountered with the Automated API PUT Approach:**
+* **Data Persistence Issue:** The Spira API `PUT` request would consistently return a `200 OK` status, but the custom field value containing the Confluence link was often not actually saved/persisted to the Spira database (this was verified by performing a hard browser refresh after the operation). The exact cause for this silent non-persistence despite a successful API response remains undetermined.
+* **SpiraApp Storage 500 Error:** Calls to `spiraAppManager.storageGetProduct` (used for attempting to cache the `PropertyDefinitionId`) consistently resulted in a 500 Internal Server Error from the Spira backend service (`PluginService.svc/PluginStorage_Retrieve`). This rendered the caching strategy for `PropertyDefinitionId` ineffective for retrieval, forcing a fallback to fetching the ID from the template on every relevant operation. This 500 error may indicate an underlying issue with the SpiraApp storage service in the target Spira instance.
+
+The JavaScript file (`confluence.js`) contains the currently active `updateFormField` logic, as well as the original API-based update functions commented out for detailed reference and potential future discussion or debugging.
+
+## Known Issues / Minor Usability Notes
+
+* After a new Confluence page link is automatically populated into the custom field on the Spira Requirement form, the user may need to click into that custom field first to make Spira's main "Save" button become active.
+
+---

--- a/confluence.js
+++ b/confluence.js
@@ -1,123 +1,197 @@
-// --- confluence.js (Conditional Link Version) ---
+// --- confluence.js (Fixing Scope, Focusing on Spira PUT) ---
 "use strict";
 
+// Register the main handler function
 try {
-    // Make sure this registers the 'handleConfluenceLink' function below
     spiraAppManager.registerEvent_menuEntryClick(APP_GUID, "openConfluenceLink", handleConfluenceLink);
 } catch (err) {
     console.error("Error registering Confluence menu click handler:", err);
 }
 
-/**
- * Checks for an existing link in a custom field. If found, navigates there.
- * Otherwise, constructs the Confluence "Create Page" URL and navigates.
- * THIS IS THE MAIN FUNCTION CALLED BY THE BUTTON CLICK.
- */
+// Main handler (mostly unchanged)
 function handleConfluenceLink() {
     console.log("Confluence > Handle Link button clicked.");
-
-    // --- 1. Get Settings (including the custom field name) ---
-    // Reads the 'confluenceLinkFieldName' setting you configure in Spira Product Admin
     let linkFieldName = SpiraAppSettings[APP_GUID]?.confluenceLinkFieldName;
 
     if (!linkFieldName || !linkFieldName.startsWith("Custom_")) {
-        spiraAppManager.displayErrorMessage("Confluence Link Custom Field Name setting is missing or invalid (must be like 'Custom_XX'). Please configure it in Product Settings.");
+        spiraAppManager.displayErrorMessage("Confluence Link Custom Field Name setting missing/invalid.");
         return;
     }
     console.log(`Checking custom field: ${linkFieldName}`);
-
-    // --- 2. Check Existing Link ---
     let existingUrl = "";
     try {
-        // Reads the value from the specified custom field on the current Requirement
         existingUrl = spiraAppManager.getDataItemField(linkFieldName, "textValue");
-    } catch (err) {
-        console.warn(`Could not read custom field ${linkFieldName}: ${err.message}`);
-        existingUrl = ""; // Treat as empty if error reading
-    }
+    } catch (err) { /* ignore */ }
 
-    // --- 3. Decide Where to Go (The Core Logic)---
-    if (existingUrl && existingUrl.trim() !== "") {
-        // IF Custom field has a value, navigate there directly
-        console.log(`Found existing URL: ${existingUrl}. Navigating...`);
-        if (existingUrl.toLowerCase().startsWith('http')) {
-             spiraAppManager.setWindowLocation(existingUrl);
-        } else {
-             console.error(`Value in ${linkFieldName} does not look like a valid URL: ${existingUrl}`);
-             spiraAppManager.displayErrorMessage(`The value in the custom field '${linkFieldName}' doesn't look like a valid URL. Cannot navigate.`);
-        }
+    if (existingUrl && existingUrl.trim() !== "" && existingUrl.toLowerCase().startsWith('http')) {
+        console.log(`Found existing URL: ${existingUrl}. Opening in new tab...`);
+        window.open(existingUrl, '_blank');
     } else {
-        // ELSE Custom field is empty, call the function to build the create page link
-        console.log(`Custom field ${linkFieldName} is empty. Constructing 'Create Page' URL...`);
-        constructAndNavigateToCreateUrl(); // Go to the 'create' logic
+        if (existingUrl && existingUrl.trim() !== "") { console.warn(`Value in ${linkFieldName} invalid. Creating page.`); }
+        console.log(`Custom field ${linkFieldName} empty/invalid. Creating page via API...`);
+        createConfluencePageViaApiAndUpdateSpira(linkFieldName);
     }
 }
 
-/**
- * Constructs the Confluence "Create Page" URL and navigates.
- * (This function is called by handleConfluenceLink if no existing URL is found)
- */
-function constructAndNavigateToCreateUrl() {
-    console.log("Constructing 'Create Page' URL.");
+// Function to create Confluence Page and Update Spira
+function createConfluencePageViaApiAndUpdateSpira(spiraLinkFieldName) {
+    console.log("Attempting to create Confluence page via API...");
 
-    // --- Get Spira Requirement Data ---
-    let requirementId = null;
-    let requirementName = "";
-    try {
-        requirementId = spiraAppManager.getDataItemField("RequirementId", "intValue");
-        requirementName = spiraAppManager.getDataItemField("Name", "textValue");
+    // --- Declare newPageUrl here to make it available to callbacks ---
+    let newPageUrl = "";
 
-        if (requirementId === null || requirementId === undefined || !requirementName) {
-             spiraAppManager.displayErrorMessage("Could not retrieve Requirement ID and Name for creating link.");
-            return;
-        }
-        console.log(`Req ID: ${requirementId}, Name: ${requirementName}`);
-    } catch (err) {
-        console.error("Confluence App - Error getting Requirement data for create:", err);
-        spiraAppManager.displayErrorMessage("Error retrieving Requirement data for create link: " + err.message);
-        return;
-    }
-
-    // --- Get Settings for Create URL ---
+    // --- Get Spira Data & Settings ---
+    let requirementId = spiraAppManager.artifactId;
+    let requirementName = spiraAppManager.getDataItemField("Name", "textValue");
+    let projectId = spiraAppManager.projectId;
     let spaceKey = SpiraAppSettings[APP_GUID]?.confluenceSpaceKey;
-    let parentPageId = SpiraAppSettings[APP_GUID]?.confluenceParentPageId; // This is an integer
-    let createPath = SpiraAppSettings[APP_GUID]?.confluenceCreatePath;   // e.g., /wiki/create-content/page
-    let baseUrl = SpiraAppSettings[APP_GUID]?.confluenceBaseUrl || '';     // From system settings
+    let parentPageId = SpiraAppSettings[APP_GUID]?.confluenceParentPageId;
+    let confluenceBaseUrlFromSettings = SpiraAppSettings[APP_GUID]?.confluenceBaseUrl;
+    const spiraPublicBaseUrl = window.location.origin;
+    console.log("Using Spira Base for link-back:", spiraPublicBaseUrl);
 
-    if (!baseUrl) {
-         spiraAppManager.displayErrorMessage("Confluence Base URL is not configured in System Settings.");
-         return;
-     }
-     if (!spaceKey || !createPath) {
-        spiraAppManager.displayErrorMessage("Confluence Space Key and Create Path must be configured in Product Settings for creating link.");
-        return;
+    // Basic validation
+    if (!requirementName || !confluenceBaseUrlFromSettings || !spiraPublicBaseUrl || !spaceKey) {
+        spiraAppManager.displayErrorMessage("Required settings or data missing."); return;
     }
+    confluenceBaseUrlFromSettings = confluenceBaseUrlFromSettings.replace(/\/$/, '');
 
-    // Clean up paths
-    baseUrl = baseUrl.replace(/\/$/, '');
-    if (createPath && !createPath.startsWith('/')) {
-        createPath = '/' + createPath;
-    }
+    // --- Construct Confluence API Request ---
+    const fullyConstructedEndpoint = `${confluenceBaseUrlFromSettings}/wiki/rest/api/content`;
+    // Construct Spira link for Confluence body
+    const spiraLinkHtml = `<p>This page is linked to Spira Requirement <a href="${spiraPublicBaseUrl}/#/project/${projectId}/requirement/${requirementId}">${requirementName} (REQ:${requirementId})</a>.</p><p>Further details about the requirement can be found in Spira.</p>`;
+    console.log("DEBUG: Link-back HTML:", spiraLinkHtml); // Log the link specifically
 
-    // --- Construct the URL ---
-    let encodedTitle = encodeURIComponent(`[REQ:${requirementId}] ${requirementName}`);
-    
-    // Start with the base path from settings
-    let constructedUrl = `${baseUrl}${createPath}`;
-    
-    // Add the dynamic query parameters
-    constructedUrl += `?spaceKey=${encodeURIComponent(spaceKey)}`;
-    constructedUrl += `&title=${encodedTitle}`; // Confluence should pre-fill this title
-    
-    if (parentPageId !== null && parentPageId !== undefined && parentPageId > 0) {
-        constructedUrl += `&parentPageId=${parentPageId}`;
-    }
+    let requestBody = { type: "page", title: `[REQ:${requirementId}] ${requirementName}`, space: { key: spaceKey }, body: { storage: { value: spiraLinkHtml, representation: "storage" }}};
+    if (parentPageId && parentPageId > 0) { requestBody.ancestors = [{ id: parseInt(parentPageId, 10) }]; }
 
-    // NOW ADD THE STATIC PARAMETERS YOU FOUND
-    constructedUrl += `&withFallback=true&source=globalCreateDropdown-page`;
+    const credentialsForConfluence = { userName: "{confluenceApiEmail}", password: "{confluenceApiToken}" };
+    const headers = { "Content-Type": "application/json", "Accept": "application/json" };
 
-    console.log(`Constructed Create URL: ${constructedUrl}`);
+    console.log("DEBUG: Endpoint:", fullyConstructedEndpoint);
+    console.log("DEBUG: Credentials:", JSON.stringify(credentialsForConfluence));
+    console.log("DEBUG: Headers:", JSON.stringify(headers));
+    console.log("DEBUG: Request Body:", JSON.stringify(requestBody));
 
-    // --- Navigate ---
-    spiraAppManager.setWindowLocation(constructedUrl);
+    spiraAppManager.displaySuccessMessage("Creating page in Confluence...");
+
+    // --- Call Confluence API ---
+    spiraAppManager.executeRest(
+        APP_GUID, "Confluence SpiraApp", "POST", fullyConstructedEndpoint,
+        JSON.stringify(requestBody), credentialsForConfluence, headers,
+        function(confluenceResponse) { // SUCCESS CALLBACK (Confluence)
+            console.log("Confluence page created successfully (RAW Response Wrapper):", confluenceResponse);
+            // Reset URL in case of multiple runs / errors
+            newPageUrl = "";
+            let parsedContent = null;
+            try {
+                if (confluenceResponse && typeof confluenceResponse.content === 'string') {
+                    parsedContent = JSON.parse(confluenceResponse.content);
+                    console.log("Parsed Confluence Response Content:", parsedContent);
+                } else { throw new Error("Response content missing/invalid."); }
+
+                // Extract URL
+                if (parsedContent._links?.base && parsedContent._links?.webui) { newPageUrl = parsedContent._links.base + parsedContent._links.webui; }
+                else if (parsedContent._links?.base && parsedContent._links?.tinyui) { newPageUrl = parsedContent._links.base + parsedContent._links.tinyui; }
+                else if (parsedContent.id) { newPageUrl = `${confluenceBaseUrlFromSettings}/wiki/spaces/${spaceKey}/pages/${parsedContent.id}`; }
+                else { throw new Error("Parsed response missing links or id."); }
+
+                console.log("Determined new page URL:", newPageUrl);
+                updateSpiraRequirementLink(projectId, requirementId, spiraLinkFieldName, newPageUrl); // Update Spira
+
+            } catch (parseError) {
+                spiraAppManager.displayErrorMessage("Confluence page created, but failed to process response or find URL.");
+                console.error("Error processing Confluence response:", parseError, confluenceResponse.content);
+                // Try to open generic Confluence home page in new tab on failure?
+                window.open(confluenceBaseUrlFromSettings + '/wiki', '_blank');
+            }
+        },
+        function(errorStatus, errorThrown) { // ERROR CALLBACK (Confluence)
+             // ... (Keep existing error handling logic here) ...
+             console.error("Error creating Confluence page:", errorStatus, errorThrown);
+             let errorDetail = "..."; // Extract error detail as before
+             spiraAppManager.displayErrorMessage(`Failed to create Confluence page. ...`);
+        }
+    );
+}
+
+
+// Function to Update Spira Requirement via API
+function updateSpiraRequirementLink(projectId, requirementId, fieldName, newUrl) {
+    console.log(`Attempting to update Spira Req ${requirementId} via API, field ${fieldName} with URL: ${newUrl}`);
+    const getUrl = `projects/${projectId}/requirements/${requirementId}`;
+
+    spiraAppManager.executeApi("Confluence SpiraApp", "7.0", "GET", getUrl, null,
+        function(requirementData) { // Success GET
+            console.log("Got Spira Req data for update:", requirementData);
+
+            // --- !!! CRITICAL STEP !!! ---
+            // --- Construct the 'updatePayload' EXACTLY as required by Spira's PUT /requirements endpoint ---
+            // --- You MUST consult the Spira API documentation for this ---
+            let updatePayload = {
+                RequirementId: requirementData.RequirementId,
+                ConcurrencyDate: requirementData.ConcurrencyDate, // Usually required
+                // Other required fields ??? (e.g., StatusId, TypeId might be needed even if not changing)
+                CustomProperties: requirementData.CustomProperties || []
+            };
+
+            let customPropFound = false;
+            updatePayload.CustomProperties.forEach(prop => {
+                // Check Name/PropertyName based on Spira GET response structure
+                if (prop.PropertyName === fieldName || prop.Name === fieldName) {
+                    prop.StringValue = newUrl; // Update existing
+                    customPropFound = true;
+                    // Ensure DefinitionId (if present/required) is correct
+                }
+            });
+
+            if (!customPropFound) {
+                // Add new - CHECK API DOCS for required fields in this object!
+                updatePayload.CustomProperties.push({
+                    PropertyName: fieldName, // Or Name?
+                    // DefinitionId: ???, // Likely needed! Find the ID for Custom_10
+                    StringValue: newUrl
+                    // FieldType: ??? // Usually not needed if DefinitionId is provided
+                });
+            }
+            // --- End Critical Step ---
+
+            console.log("Prepared Spira Update Payload:", JSON.stringify(updatePayload, null, 2)); // Log formatted payload
+
+            const updateUrl = `projects/${projectId}/requirements`;
+
+            spiraAppManager.executeApi("Confluence SpiraApp", "7.0", "PUT", updateUrl, JSON.stringify(updatePayload),
+                function(updateResponse) { // Success PUT
+                    console.log("Spira Req updated successfully via API:", updateResponse);
+                    spiraAppManager.displaySuccessMessage("Confluence page created and Spira link updated!");
+                    console.log("Attempting to open NEW URL in new tab:", newUrl);
+                    window.open(newUrl, '_blank'); // Open new tab on SUCCESS
+                    setTimeout(() => spiraAppManager.reloadForm(), 500);
+                },
+                function(spiraUpdateErrorStatus, spiraUpdateErrorThrown) { // Error PUT
+                    console.error("Error updating Spira Req via API:", spiraUpdateErrorStatus, spiraUpdateErrorThrown);
+                    // Try to get error details from Spira response
+                     let errorDetail = (typeof spiraUpdateErrorThrown === 'object' && spiraUpdateErrorThrown !== null) ? JSON.stringify(spiraUpdateErrorThrown) : spiraUpdateErrorThrown;
+                     if (typeof spiraUpdateErrorStatus === 'object' && spiraUpdateErrorStatus !== null && spiraUpdateErrorStatus.ExceptionMessage) {
+                         errorDetail = spiraUpdateErrorStatus.ExceptionMessage; // Spira often puts errors here
+                     } else if (typeof spiraUpdateErrorStatus === 'object' && spiraUpdateErrorStatus !== null && spiraUpdateErrorStatus.statusText) {
+                         errorDetail = spiraUpdateErrorStatus.statusText;
+                     }
+                    spiraAppManager.displayWarningMessage(`Confluence page created (${newPageUrl}), but failed to update Spira link via API. Error: ${errorDetail}. Please update manually.`);
+                    console.log("Attempting to open NEW URL in new tab (after Spira update failure):", newPageUrl);
+                    window.open(newPageUrl, '_blank'); // Still open Confluence page
+                }
+            );
+        },
+        function(getReqErrorStatus, getReqErrorThrown) { // Error GET
+            console.error("Error GETting Spira Req before update:", getReqErrorStatus, getReqErrorThrown);
+            let errorDetail = "..."; // Extract error detail as above
+            spiraAppManager.displayWarningMessage(`Confluence page created, but couldn't get Spira data to update link. Error: ${errorDetail}. Please link manually.`);
+            // newPageUrl declared in outer scope should be available if Confluence call succeeded
+            if (newPageUrl) {
+                console.log("Attempting to open NEW URL in new tab (after Spira GET failure):", newPageUrl);
+                window.open(newPageUrl, '_blank');
+            }
+        }
+    );
 }

--- a/confluence.js
+++ b/confluence.js
@@ -1,197 +1,421 @@
-// --- confluence.js (Fixing Scope, Focusing on Spira PUT) ---
+// --- confluence.js (Revised for updateFormField - FULL FILE) ---
 "use strict";
 
-// Register the main handler function
+// Register the main handler function for the menu click
 try {
-    spiraAppManager.registerEvent_menuEntryClick(APP_GUID, "openConfluenceLink", handleConfluenceLink);
+    // Ensure APP_GUID is available (it's provided by Spira when the script is loaded)
+    if (typeof APP_GUID === 'undefined') {
+        console.error("SpiraApp Critical Error: APP_GUID is not defined. Cannot register menu click.");
+        // Display error to user only if spiraAppManager is available
+        if (typeof spiraAppManager !== 'undefined' && spiraAppManager.displayErrorMessage) {
+            spiraAppManager.displayErrorMessage("SpiraApp initialization error. Please contact support (APP_GUID missing).");
+        }
+    } else {
+        spiraAppManager.registerEvent_menuEntryClick(APP_GUID, "openConfluenceLink", handleConfluenceLink);
+    }
 } catch (err) {
-    console.error("Error registering Confluence menu click handler:", err);
+    console.error("SpiraApp Error: Failed to register Confluence menu click handler.", err);
+    if (typeof spiraAppManager !== 'undefined' && spiraAppManager.displayErrorMessage) {
+        spiraAppManager.displayErrorMessage("SpiraApp critical error during setup. Menu button may not work.");
+    }
 }
 
-// Main handler (mostly unchanged)
+// ==================================================================================
+// Main Function - Called When Button is Clicked
+// ==================================================================================
 function handleConfluenceLink() {
     console.log("Confluence > Handle Link button clicked.");
-    let linkFieldName = SpiraAppSettings[APP_GUID]?.confluenceLinkFieldName;
+    const linkFieldName = SpiraAppSettings[APP_GUID]?.confluenceLinkFieldName;
 
     if (!linkFieldName || !linkFieldName.startsWith("Custom_")) {
-        spiraAppManager.displayErrorMessage("Confluence Link Custom Field Name setting missing/invalid.");
+        spiraAppManager.displayErrorMessage("SpiraApp Config Error: 'Link Custom Field Name' (e.g., Custom_10) setting is missing or invalid in Product Settings.");
         return;
     }
     console.log(`Checking custom field: ${linkFieldName}`);
+
     let existingUrl = "";
     try {
         existingUrl = spiraAppManager.getDataItemField(linkFieldName, "textValue");
-    } catch (err) { /* ignore */ }
+    } catch (err) {
+        console.warn(`Could not read custom field '${linkFieldName}' using getDataItemField: ${err.message}. This can happen if the field isn't on the page layout or has no value. Assuming empty.`);
+        existingUrl = ""; // Default to empty if there's an error reading it
+    }
 
-    if (existingUrl && existingUrl.trim() !== "" && existingUrl.toLowerCase().startsWith('http')) {
+    if (existingUrl && existingUrl.trim() !== "" && (existingUrl.toLowerCase().startsWith('http://') || existingUrl.toLowerCase().startsWith('https://'))) {
         console.log(`Found existing URL: ${existingUrl}. Opening in new tab...`);
         window.open(existingUrl, '_blank');
     } else {
-        if (existingUrl && existingUrl.trim() !== "") { console.warn(`Value in ${linkFieldName} invalid. Creating page.`); }
-        console.log(`Custom field ${linkFieldName} empty/invalid. Creating page via API...`);
-        createConfluencePageViaApiAndUpdateSpira(linkFieldName);
+        if (existingUrl && existingUrl.trim() !== "") {
+            console.warn(`Value in '${linkFieldName}' ('${existingUrl}') is present but not a valid http/https URL. Proceeding to create new page.`);
+        }
+        console.log(`Custom field '${linkFieldName}' is empty or does not contain a valid URL. Initiating Confluence page creation and Spira update flow...`);
+        createConfluencePageAndLinkToSpira(linkFieldName);
     }
 }
 
-// Function to create Confluence Page and Update Spira
-function createConfluencePageViaApiAndUpdateSpira(spiraLinkFieldName) {
-    console.log("Attempting to create Confluence page via API...");
+// ==================================================================================
+// Orchestrator for Creating Confluence Page & Then Kicking Off Spira Form Update
+// ==================================================================================
+function createConfluencePageAndLinkToSpira(spiraLinkFieldName) {
+    console.log("Create Confluence Page Flow: Started.");
 
-    // --- Declare newPageUrl here to make it available to callbacks ---
-    let newPageUrl = "";
+    // Retrieve necessary IDs and settings
+    const requirementId = spiraAppManager.artifactId;
+    const requirementName = spiraAppManager.getDataItemField("Name", "textValue"); // Assumes "Name" field is always available
+    const projectId = spiraAppManager.projectId;
 
-    // --- Get Spira Data & Settings ---
-    let requirementId = spiraAppManager.artifactId;
-    let requirementName = spiraAppManager.getDataItemField("Name", "textValue");
-    let projectId = spiraAppManager.projectId;
-    let spaceKey = SpiraAppSettings[APP_GUID]?.confluenceSpaceKey;
-    let parentPageId = SpiraAppSettings[APP_GUID]?.confluenceParentPageId;
-    let confluenceBaseUrlFromSettings = SpiraAppSettings[APP_GUID]?.confluenceBaseUrl;
-    const spiraPublicBaseUrl = window.location.origin;
-    console.log("Using Spira Base for link-back:", spiraPublicBaseUrl);
+    const confluenceBaseUrlFromSettings = SpiraAppSettings[APP_GUID]?.confluenceBaseUrl;
+    const spaceKey = SpiraAppSettings[APP_GUID]?.confluenceSpaceKey;
+    const parentPageIdSetting = SpiraAppSettings[APP_GUID]?.confluenceParentPageId; // Manifest defines as integer type
 
-    // Basic validation
-    if (!requirementName || !confluenceBaseUrlFromSettings || !spiraPublicBaseUrl || !spaceKey) {
-        spiraAppManager.displayErrorMessage("Required settings or data missing."); return;
+    // Use window.location.origin for Spira's public base URL for the link-back
+    const spiraPublicBaseUrl = window.location.origin.replace(/\/$/, ''); // Ensure no trailing slash
+    console.log("Using Spira Base URL for link-back construction:", spiraPublicBaseUrl);
+
+    // Basic validation for required settings and data
+    if (!requirementId) { spiraAppManager.displayErrorMessage("SpiraApp Error: Could not retrieve current Requirement ID."); return; }
+    if (!requirementName) { spiraAppManager.displayErrorMessage("SpiraApp Error: Could not retrieve Requirement Name."); return; }
+    if (!projectId) { spiraAppManager.displayErrorMessage("SpiraApp Error: Could not retrieve current Project ID."); return; }
+    if (!confluenceBaseUrlFromSettings) { spiraAppManager.displayErrorMessage("SpiraApp Config Error: 'Confluence Base URL' system setting is missing."); return; }
+    if (!spaceKey) { spiraAppManager.displayErrorMessage("SpiraApp Config Error: 'Target Confluence Space Key' product setting is missing."); return; }
+    // Credentials (confluenceApiEmail, confluenceApiToken) are handled by spiraAppManager.executeRest using tokens from settings.
+
+    const cleanConfluenceBaseUrl = confluenceBaseUrlFromSettings.replace(/\/$/, ''); // Ensure no trailing slash
+    const confluenceApiEndpoint = `${cleanConfluenceBaseUrl}/wiki/rest/api/content`;
+
+    // Construct the HTML content for the new Confluence page, linking back to the Spira Requirement
+    const spiraLinkHtml = `<p>This page is linked to Spira Requirement <a href="${spiraPublicBaseUrl}/#/project/${projectId}/requirement/${requirementId}">${requirementName} (REQ:${requirementId})</a>.</p><p>Further details about the requirement can be found by following the link back to Spira.</p>`;
+    console.log("DEBUG: Link-back HTML for Confluence page:", spiraLinkHtml);
+
+    let requestBody = {
+        type: "page",
+        title: `[REQ:${requirementId}] ${requirementName}`, // Confluence page title
+        space: { key: spaceKey },
+        body: {
+            storage: { // Confluence storage format
+                value: spiraLinkHtml,
+                representation: "storage"
+            }
+        }
+    };
+
+    // Add parent page ID if provided and valid
+    if (parentPageIdSetting && typeof parentPageIdSetting === 'number' && parentPageIdSetting > 0) {
+        requestBody.ancestors = [{ id: parentPageIdSetting }]; // API expects integer
+    } else if (parentPageIdSetting && typeof parentPageIdSetting === 'string' && parentPageIdSetting.trim() !== "") { // Handle if it was somehow passed as string
+        const parsedParentId = parseInt(parentPageIdSetting.trim(), 10);
+        if (!isNaN(parsedParentId) && parsedParentId > 0) {
+            requestBody.ancestors = [{ id: parsedParentId }];
+        } else {
+            console.warn(`Configured 'Target Parent Page ID' ('${parentPageIdSetting}') is not a valid positive integer. New page will be created at the space root.`);
+        }
     }
-    confluenceBaseUrlFromSettings = confluenceBaseUrlFromSettings.replace(/\/$/, '');
 
-    // --- Construct Confluence API Request ---
-    const fullyConstructedEndpoint = `${confluenceBaseUrlFromSettings}/wiki/rest/api/content`;
-    // Construct Spira link for Confluence body
-    const spiraLinkHtml = `<p>This page is linked to Spira Requirement <a href="${spiraPublicBaseUrl}/#/project/${projectId}/requirement/${requirementId}">${requirementName} (REQ:${requirementId})</a>.</p><p>Further details about the requirement can be found in Spira.</p>`;
-    console.log("DEBUG: Link-back HTML:", spiraLinkHtml); // Log the link specifically
-
-    let requestBody = { type: "page", title: `[REQ:${requirementId}] ${requirementName}`, space: { key: spaceKey }, body: { storage: { value: spiraLinkHtml, representation: "storage" }}};
-    if (parentPageId && parentPageId > 0) { requestBody.ancestors = [{ id: parseInt(parentPageId, 10) }]; }
-
-    const credentialsForConfluence = { userName: "{confluenceApiEmail}", password: "{confluenceApiToken}" };
+    const credentialsForConfluence = { userName: "{confluenceApiEmail}", password: "{confluenceApiToken}" }; // Tokens resolved by executeRest
     const headers = { "Content-Type": "application/json", "Accept": "application/json" };
 
-    console.log("DEBUG: Endpoint:", fullyConstructedEndpoint);
-    console.log("DEBUG: Credentials:", JSON.stringify(credentialsForConfluence));
-    console.log("DEBUG: Headers:", JSON.stringify(headers));
-    console.log("DEBUG: Request Body:", JSON.stringify(requestBody));
+    console.log("DEBUG Confluence API Call - Endpoint:", confluenceApiEndpoint);
+    console.log("DEBUG Confluence API Call - Headers:", JSON.stringify(headers));
+    console.log("DEBUG Confluence API Call - Body:", JSON.stringify(requestBody));
 
-    spiraAppManager.displaySuccessMessage("Creating page in Confluence...");
+    spiraAppManager.displaySuccessMessage("Attempting to create page in Confluence..."); // Temporary message, will be hidden
 
-    // --- Call Confluence API ---
+    // --- Call Confluence API using spiraAppManager.executeRest ---
     spiraAppManager.executeRest(
-        APP_GUID, "Confluence SpiraApp", "POST", fullyConstructedEndpoint,
-        JSON.stringify(requestBody), credentialsForConfluence, headers,
-        function(confluenceResponse) { // SUCCESS CALLBACK (Confluence)
-            console.log("Confluence page created successfully (RAW Response Wrapper):", confluenceResponse);
-            // Reset URL in case of multiple runs / errors
-            newPageUrl = "";
-            let parsedContent = null;
+        APP_GUID, // SpiraApp's GUID
+        "ConfluenceSpiraApp_CreatePage", // Name for logging
+        "POST", // HTTP method
+        confluenceApiEndpoint, // URL
+        JSON.stringify(requestBody), // Body
+        credentialsForConfluence, // Credentials object with tokens
+        headers, // Headers
+        function(confluenceResponseWrapper) { // SUCCESS CALLBACK (Confluence Page Creation)
+            console.log("Confluence page creation - RAW Response Wrapper from Spira server:", confluenceResponseWrapper);
+            let newPageUrl = ""; // Initialize for this scope
+
             try {
-                if (confluenceResponse && typeof confluenceResponse.content === 'string') {
-                    parsedContent = JSON.parse(confluenceResponse.content);
-                    console.log("Parsed Confluence Response Content:", parsedContent);
-                } else { throw new Error("Response content missing/invalid."); }
+                if (!confluenceResponseWrapper || typeof confluenceResponseWrapper.content !== 'string' || confluenceResponseWrapper.content.trim() === "") {
+                    throw new Error("Confluence API response content from Spira server is missing, empty, or not a string.");
+                }
+                // The actual Confluence response is nested inside the 'content' property of the wrapper
+                const parsedConfluenceContent = JSON.parse(confluenceResponseWrapper.content);
+                console.log("Parsed Confluence API Response Content:", parsedConfluenceContent);
 
-                // Extract URL
-                if (parsedContent._links?.base && parsedContent._links?.webui) { newPageUrl = parsedContent._links.base + parsedContent._links.webui; }
-                else if (parsedContent._links?.base && parsedContent._links?.tinyui) { newPageUrl = parsedContent._links.base + parsedContent._links.tinyui; }
-                else if (parsedContent.id) { newPageUrl = `${confluenceBaseUrlFromSettings}/wiki/spaces/${spaceKey}/pages/${parsedContent.id}`; }
-                else { throw new Error("Parsed response missing links or id."); }
+                // Construct the user-friendly URL to the new Confluence page
+                if (parsedConfluenceContent._links?.base && parsedConfluenceContent._links?.webui) {
+                    newPageUrl = parsedConfluenceContent._links.base + parsedConfluenceContent._links.webui;
+                } else if (parsedConfluenceContent.id && parsedConfluenceContent.space?.key) { // Construct from id and space key if standard links are missing
+                    newPageUrl = `${cleanConfluenceBaseUrl}/wiki/spaces/${parsedConfluenceContent.space.key}/pages/${parsedConfluenceContent.id}`;
+                } else if (parsedConfluenceContent.id) { // Fallback: use configured spaceKey if response doesn't include it (less ideal)
+                     newPageUrl = `${cleanConfluenceBaseUrl}/wiki/spaces/${spaceKey}/pages/${parsedConfluenceContent.id}`;
+                } else {
+                    throw new Error("Parsed Confluence response is missing expected _links or id to construct the page URL.");
+                }
 
-                console.log("Determined new page URL:", newPageUrl);
-                updateSpiraRequirementLink(projectId, requirementId, spiraLinkFieldName, newPageUrl); // Update Spira
+                console.log("Determined new Confluence page URL:", newPageUrl);
+                spiraAppManager.hideMessage(); // Hide the "Attempting to create..." message
 
-            } catch (parseError) {
-                spiraAppManager.displayErrorMessage("Confluence page created, but failed to process response or find URL.");
-                console.error("Error processing Confluence response:", parseError, confluenceResponse.content);
-                // Try to open generic Confluence home page in new tab on failure?
-                window.open(confluenceBaseUrlFromSettings + '/wiki', '_blank');
+                // Update the Spira form field with the new URL
+                updateSpiraRequirementFormField(spiraLinkFieldName, newPageUrl);
+
+            } catch (e) {
+                spiraAppManager.displayErrorMessage("Confluence page may have been created, but an error occurred while processing the Confluence response or determining its URL. Please check Confluence manually.");
+                console.error("Error processing Confluence response:", e, "Raw wrapper content:", confluenceResponseWrapper?.content);
+                // Optionally, try to open Confluence to the space as a fallback
+                if (cleanConfluenceBaseUrl && spaceKey) { window.open(cleanConfluenceBaseUrl + '/wiki/spaces/' + spaceKey, '_blank'); }
             }
         },
-        function(errorStatus, errorThrown) { // ERROR CALLBACK (Confluence)
-             // ... (Keep existing error handling logic here) ...
-             console.error("Error creating Confluence page:", errorStatus, errorThrown);
-             let errorDetail = "..."; // Extract error detail as before
-             spiraAppManager.displayErrorMessage(`Failed to create Confluence page. ...`);
+        function(errorStatus, errorThrown) { // ERROR CALLBACK (Confluence Page Creation)
+            console.error("Confluence Page Creation API call failed - Status from Spira Server:", errorStatus, "Error/Exception:", errorThrown);
+            let displayError = "Failed to create Confluence page via API.";
+            if (errorStatus && errorStatus.responseText) { // Spira's wrapper for a failed REST call might have details here
+                try {
+                    const errResp = JSON.parse(errorStatus.responseText); // This might be Spira's error structure
+                    if (errResp.Message) displayError += ` Details: ${errResp.Message}`;
+                    else if (errResp.ExceptionMessage) displayError += ` Details: ${errResp.ExceptionMessage}`; // Another common Spira error property
+                } catch (e) { /* Could not parse Spira's error response, use raw if short */ displayError += " Could not parse error details from server."; }
+            } else if (errorThrown) { // This might be a network error or a string description
+                displayError += ` Error description: ${errorThrown}`;
+            }
+            spiraAppManager.displayErrorMessage(displayError);
         }
     );
 }
 
+// ==================================================================================
+// Function to Update Spira Requirement Form Field (using updateFormField)
+// ==================================================================================
+function updateSpiraRequirementFormField(fieldName, newPageUrl) {
+    console.log(`Attempting to update Spira form field '${fieldName}' with URL: ${newPageUrl}`);
+    try {
+        // The dataProperty for a text custom field is typically "StringValue" for the API model,
+        // but for updateFormField, it might also be "textValue" or just the direct value.
+        // Let's try "StringValue" first as it's more aligned with the custom property structure.
+        // If that doesn't work, "textValue" would be the next to try.
+        //spiraAppManager.updateFormField(fieldName, "StringValue", newPageUrl); // Try a different value type
+        spiraAppManager.updateFormField(fieldName, "textValue", newPageUrl);
+        console.log(`Form field '${fieldName}' updated in UI with new URL.`);
+        spiraAppManager.displaySuccessMessage(`Confluence page created. Link has been populated into the '${fieldName}' field on this form. Please click Spira's 'Save' button to persist this change.`);
 
-// Function to Update Spira Requirement via API
-function updateSpiraRequirementLink(projectId, requirementId, fieldName, newUrl) {
-    console.log(`Attempting to update Spira Req ${requirementId} via API, field ${fieldName} with URL: ${newUrl}`);
-    const getUrl = `projects/${projectId}/requirements/${requirementId}`;
+        // Open the Confluence page in a new tab
+        if (newPageUrl) {
+            console.log("Opening newly created Confluence page in a new tab:", newPageUrl);
+            window.open(newPageUrl, '_blank');
+        }
+    } catch (e) {
+        console.error(`Error calling spiraAppManager.updateFormField for field '${fieldName}':`, e);
+        spiraAppManager.displayErrorMessage(`Confluence page was created successfully (${newPageUrl}), but there was an error populating the link into the Spira form field '${fieldName}'. Error: ${e.message}. Please copy the URL and paste it manually into the field, then click 'Save'.`);
+        // Still open the Confluence page so the user can at least access it
+        if (newPageUrl) {
+            window.open(newPageUrl, '_blank');
+        }
+    }
+}
 
-    spiraAppManager.executeApi("Confluence SpiraApp", "7.0", "GET", getUrl, null,
-        function(requirementData) { // Success GET
-            console.log("Got Spira Req data for update:", requirementData);
 
-            // --- !!! CRITICAL STEP !!! ---
-            // --- Construct the 'updatePayload' EXACTLY as required by Spira's PUT /requirements endpoint ---
-            // --- You MUST consult the Spira API documentation for this ---
-            let updatePayload = {
-                RequirementId: requirementData.RequirementId,
-                ConcurrencyDate: requirementData.ConcurrencyDate, // Usually required
-                // Other required fields ??? (e.g., StatusId, TypeId might be needed even if not changing)
-                CustomProperties: requirementData.CustomProperties || []
-            };
+// ==================================================================================
+// == ORIGINAL AUTOMATED SPIRA UPDATE APPROACH (via API PUT) ==
+// The functions below (`updateSpiraRequirementLink_API`, 
+// `WorkspacePropertyDefinitionIdFromTemplateAndProceed_API`, 
+// and `getRequirementAndPutUpdate_API`) represent the original attempt to 
+// automatically save the Confluence link back to the Spira Requirement 
+// using a direct Spira REST API PUT request.
+//
+// This approach was paused due to:
+// 1. Persistence Issue: API PUT returned 200 OK, but data wasn't saved.
+// 2. SpiraApp Storage 500 Error: `storageGetProduct` failed with 500,
+//    preventing reliable caching of PropertyDefinitionId.
+// 3. Complexity: Managing ConcurrencyDate, payload, etc.
+//
+// This section is retained for documentation and potential future revisiting.
+// ==================================================================================
 
-            let customPropFound = false;
-            updatePayload.CustomProperties.forEach(prop => {
-                // Check Name/PropertyName based on Spira GET response structure
-                if (prop.PropertyName === fieldName || prop.Name === fieldName) {
-                    prop.StringValue = newUrl; // Update existing
-                    customPropFound = true;
-                    // Ensure DefinitionId (if present/required) is correct
-                }
-            });
+/*
+function updateSpiraRequirementLink_API(projectId, requirementId, fieldNameFromSetting, newPageUrl) {
+    console.log(`(API Approach) Update Spira Flow: Initiated for Req ${requirementId}, Field ${fieldNameFromSetting}, URL ${newPageUrl}`);
+    const definitionIdStorageKey = `confluenceLink_defId_for_${fieldNameFromSetting}`;
+    const fieldNameCheckStorageKey = `confluenceLink_sourceFieldName_is_${fieldNameFromSetting}`;
 
-            if (!customPropFound) {
-                // Add new - CHECK API DOCS for required fields in this object!
-                updatePayload.CustomProperties.push({
-                    PropertyName: fieldName, // Or Name?
-                    // DefinitionId: ???, // Likely needed! Find the ID for Custom_10
-                    StringValue: newUrl
-                    // FieldType: ??? // Usually not needed if DefinitionId is provided
-                });
-            }
-            // --- End Critical Step ---
-
-            console.log("Prepared Spira Update Payload:", JSON.stringify(updatePayload, null, 2)); // Log formatted payload
-
-            const updateUrl = `projects/${projectId}/requirements`;
-
-            spiraAppManager.executeApi("Confluence SpiraApp", "7.0", "PUT", updateUrl, JSON.stringify(updatePayload),
-                function(updateResponse) { // Success PUT
-                    console.log("Spira Req updated successfully via API:", updateResponse);
-                    spiraAppManager.displaySuccessMessage("Confluence page created and Spira link updated!");
-                    console.log("Attempting to open NEW URL in new tab:", newUrl);
-                    window.open(newUrl, '_blank'); // Open new tab on SUCCESS
-                    setTimeout(() => spiraAppManager.reloadForm(), 500);
+    spiraAppManager.storageGetProduct(
+        APP_GUID, "ConfluenceSpiraApp_StorageGet_DefId", definitionIdStorageKey, projectId,
+        function(cachedDefIdString) { 
+            let cachedDefId = parseInt(cachedDefIdString, 10);
+            spiraAppManager.storageGetProduct(
+                APP_GUID, "ConfluenceSpiraApp_StorageGet_FieldNameCheck", fieldNameCheckStorageKey, projectId,
+                function(cachedStoredFieldName) { 
+                    if (cachedDefId && !isNaN(cachedDefId) && cachedDefId > 0 && cachedStoredFieldName === fieldNameFromSetting) {
+                        console.log(`(API Approach) Using cached PropertyDefinitionId: ${cachedDefId} for field ${fieldNameFromSetting}`);
+                        getRequirementAndPutUpdate_API(projectId, requirementId, fieldNameFromSetting, newPageUrl, cachedDefId);
+                    } else {
+                        console.log(`(API Approach) Cached PropertyDefinitionId for ${fieldNameFromSetting} is invalid. Fetching from template.`);
+                        fetchPropertyDefinitionIdFromTemplateAndProceed_API(projectId, requirementId, fieldNameFromSetting, newPageUrl, definitionIdStorageKey, fieldNameCheckStorageKey);
+                    }
                 },
-                function(spiraUpdateErrorStatus, spiraUpdateErrorThrown) { // Error PUT
-                    console.error("Error updating Spira Req via API:", spiraUpdateErrorStatus, spiraUpdateErrorThrown);
-                    // Try to get error details from Spira response
-                     let errorDetail = (typeof spiraUpdateErrorThrown === 'object' && spiraUpdateErrorThrown !== null) ? JSON.stringify(spiraUpdateErrorThrown) : spiraUpdateErrorThrown;
-                     if (typeof spiraUpdateErrorStatus === 'object' && spiraUpdateErrorStatus !== null && spiraUpdateErrorStatus.ExceptionMessage) {
-                         errorDetail = spiraUpdateErrorStatus.ExceptionMessage; // Spira often puts errors here
-                     } else if (typeof spiraUpdateErrorStatus === 'object' && spiraUpdateErrorStatus !== null && spiraUpdateErrorStatus.statusText) {
-                         errorDetail = spiraUpdateErrorStatus.statusText;
-                     }
-                    spiraAppManager.displayWarningMessage(`Confluence page created (${newPageUrl}), but failed to update Spira link via API. Error: ${errorDetail}. Please update manually.`);
-                    console.log("Attempting to open NEW URL in new tab (after Spira update failure):", newPageUrl);
-                    window.open(newPageUrl, '_blank'); // Still open Confluence page
+                function(errStorageFieldName) { 
+                    console.warn(`(API Approach) Could not retrieve fieldName check from storage. Error: ${JSON.stringify(errStorageFieldName)}. Fetching from template.`);
+                    fetchPropertyDefinitionIdFromTemplateAndProceed_API(projectId, requirementId, fieldNameFromSetting, newPageUrl, definitionIdStorageKey, fieldNameCheckStorageKey);
                 }
             );
         },
-        function(getReqErrorStatus, getReqErrorThrown) { // Error GET
-            console.error("Error GETting Spira Req before update:", getReqErrorStatus, getReqErrorThrown);
-            let errorDetail = "..."; // Extract error detail as above
-            spiraAppManager.displayWarningMessage(`Confluence page created, but couldn't get Spira data to update link. Error: ${errorDetail}. Please link manually.`);
-            // newPageUrl declared in outer scope should be available if Confluence call succeeded
-            if (newPageUrl) {
-                console.log("Attempting to open NEW URL in new tab (after Spira GET failure):", newPageUrl);
-                window.open(newPageUrl, '_blank');
-            }
+        function(errStorageDefId) { 
+            console.warn(`(API Approach) PropertyDefinitionId for ${fieldNameFromSetting} not in product storage. Error: ${JSON.stringify(errStorageDefId)}. Fetching from template.`);
+            fetchPropertyDefinitionIdFromTemplateAndProceed_API(projectId, requirementId, fieldNameFromSetting, newPageUrl, definitionIdStorageKey, fieldNameCheckStorageKey);
         }
     );
 }
+
+function fetchPropertyDefinitionIdFromTemplateAndProceed_API(projectId, requirementId, fieldNameFromSetting, newPageUrl, storageKeyForId, storageKeyForNameCheck) {
+    const projectTemplateId = spiraAppManager.projectTemplateId;
+    const artifactTypeIdForRequirement = 1; 
+    const templateUrl = `project-templates/${projectTemplateId}/custom-properties/${artifactTypeIdForRequirement}`;
+
+    console.log(`(API Approach) Fetching template custom prop defs from: ${templateUrl}`);
+
+    spiraAppManager.executeApi(
+        "ConfluenceSpiraApp_GetTemplateProps", "7.0", "GET", templateUrl, null,
+        function(templateCustomProps) { 
+            console.log("(API Approach) Template Custom Props API response:", templateCustomProps);
+            let targetPropertyDefinitionId = null;
+
+            if (templateCustomProps && Array.isArray(templateCustomProps)) {
+                const foundDef = templateCustomProps.find(def => def.CustomPropertyFieldName === fieldNameFromSetting);
+                if (foundDef && foundDef.CustomPropertyId) {
+                    targetPropertyDefinitionId = foundDef.CustomPropertyId;
+                    console.log(`(API Approach) Found PropertyDefinitionId for '${fieldNameFromSetting}' from template: ${targetPropertyDefinitionId}`);
+
+                    spiraAppManager.storageInsertProduct(APP_GUID, "ConfluenceSpiraApp_StorageInsert_DefId", storageKeyForId, targetPropertyDefinitionId.toString(), projectId, false,
+                        function() { console.log(`(API Approach) Stored PropertyDefinitionId ${targetPropertyDefinitionId} in product storage.`); },
+                        function(err) { console.error(`(API Approach) Failed to store PropertyDefinitionId in product storage.`, err); }
+                    );
+                    spiraAppManager.storageInsertProduct(APP_GUID, "ConfluenceSpiraApp_StorageInsert_FieldNameCheck", storageKeyForNameCheck, fieldNameFromSetting, projectId, false,
+                        function() { console.log(`(API Approach) Stored field name check '${fieldNameFromSetting}' in product storage.`); },
+                        function(err) { console.error(`(API Approach) Failed to store field name check in product storage.`, err); }
+                    );
+                    
+                    getRequirementAndPutUpdate_API(projectId, requirementId, fieldNameFromSetting, newPageUrl, targetPropertyDefinitionId);
+
+                } else {
+                    const errorMsg = `(API Approach) SpiraApp Config Error: Custom field '${fieldNameFromSetting}' NOT FOUND in product template.`;
+                    console.error(errorMsg, "Available props:", templateCustomProps.map(p => p.CustomPropertyFieldName)); 
+                    spiraAppManager.displayErrorMessage(errorMsg + " Cannot update Spira automatically.");
+                    if (newPageUrl) { window.open(newPageUrl, '_blank'); }
+                }
+            } else { 
+                console.error("(API Approach) Invalid response when fetching template custom properties:", templateCustomProps);
+                spiraAppManager.displayErrorMessage("(API Approach) Error: Received invalid data for template custom properties. Cannot update Spira automatically.");
+                if (newPageUrl) { window.open(newPageUrl, '_blank'); }
+            }
+        },
+        function(getTemplateErrorStatus, getTemplateErrorThrown) { 
+            console.error("(API Approach) Error GETting Template Custom Properties:", getTemplateErrorStatus, getTemplateErrorThrown);
+            let errorDetail = "..."; // Simplified error detail
+            spiraAppManager.displayErrorMessage(`(API Approach) Error fetching Spira template data. Details: ${errorDetail}. Cannot update Spira link automatically.`);
+            if (newPageUrl) { window.open(newPageUrl, '_blank'); }
+        }
+    );
+}
+
+function getRequirementAndPutUpdate_API(projectId, requirementId, fieldNameFromSetting, newPageUrl, targetPropertyDefinitionId) {
+    console.log(`(API Approach) Proceeding to GET Spira Req ${requirementId} for update with DefID ${targetPropertyDefinitionId}`);
+    const requirementGetUrl = `projects/${projectId}/requirements/${requirementId}`;
+
+    spiraAppManager.executeApi("ConfluenceSpiraApp_GetReq", "7.0", "GET", requirementGetUrl, null,
+        function(requirementData) { 
+            console.log("(API Approach) Original Spira Requirement data for update:", JSON.parse(JSON.stringify(requirementData))); 
+            let updatePayload = { ...requirementData }; 
+            
+            if (!updatePayload.ConcurrencyDate) {
+                console.error("(API Approach) CRITICAL ERROR: ConcurrencyDate is missing. Cannot safely PUT.");
+                spiraAppManager.displayErrorMessage("(API Approach) Error: Missing ConcurrencyDate. Update aborted. URL: " + newPageUrl);
+                if (newPageUrl) { window.open(newPageUrl, '_blank'); }
+                return;
+            }
+            console.log("(API Approach) Using ConcurrencyDate for PUT:", updatePayload.ConcurrencyDate);
+
+            if (!updatePayload.CustomProperties) { updatePayload.CustomProperties = []; }
+
+            let customPropToUpdate = updatePayload.CustomProperties.find(
+                p => ((p.Definition && p.Definition.CustomPropertyId === targetPropertyDefinitionId) || p.PropertyDefinitionId === targetPropertyDefinitionId)
+            );
+
+            if (customPropToUpdate) {
+                customPropToUpdate.StringValue = newPageUrl;
+                customPropToUpdate.IntegerValue = null; customPropToUpdate.BooleanValue = null;
+                customPropToUpdate.DateTimeValue = null; customPropToUpdate.DecimalValue = null;
+                customPropToUpdate.IntegerListValue = null;
+            } else {
+                updatePayload.CustomProperties.push({
+                    PropertyDefinitionId: targetPropertyDefinitionId,
+                    PropertyName: fieldNameFromSetting, 
+                    StringValue: newPageUrl,
+                    IntegerValue: null, BooleanValue: null, DateTimeValue: null, DecimalValue: null,
+                    IntegerListValue: null 
+                });
+            }
+
+            updatePayload.CustomProperties = updatePayload.CustomProperties.map(prop => {
+                let defId = prop.PropertyDefinitionId; 
+                if (!defId && prop.Definition && prop.Definition.CustomPropertyId) {
+                    defId = prop.Definition.CustomPropertyId;
+                }
+                if (!defId && prop.PropertyName === fieldNameFromSetting) {
+                     defId = targetPropertyDefinitionId;
+                }
+                let flatProp = { PropertyDefinitionId: defId };
+                if (prop.StringValue !== undefined && prop.StringValue !== null) flatProp.StringValue = prop.StringValue;
+                // ... (include other value types if they have values) ...
+                if (prop.Definition && prop.Definition.CustomPropertyFieldName) {
+                    flatProp.PropertyName = prop.Definition.CustomPropertyFieldName;
+                } else if (prop.PropertyName) {
+                    flatProp.PropertyName = prop.PropertyName;
+                }
+                return flatProp;
+            }).filter(p => p.PropertyDefinitionId != null && p.PropertyDefinitionId > 0); 
+
+            const fieldsToRemove = [
+                "Steps", "ProjectGuid", "AuthorGuid", "OwnerGuid", "ReleaseGuid", "AuthorName",
+                "OwnerName", "StatusName", "ImportanceName", "ProjectName", "RequirementTypeName",
+                "ReleaseVersionNumber", "IndentLevel", "CoverageCountTotal", "CoverageCountPassed", 
+                "CoverageCountFailed", "CoverageCountCaution", "CoverageCountBlocked", "TaskEstimatedEffort", 
+                "TaskActualEffort", "TaskCount", "PercentComplete", "IsSuspect", "Summary", "IsAttachments",
+                "Tags", "Guid", "ArtifactTypeId", "ProjectGroupName", "Definition", "LastUpdateDate" // Added LastUpdateDate
+            ];
+            fieldsToRemove.forEach(field => delete updatePayload[field]);
+
+             if (updatePayload.CustomProperties) {
+                updatePayload.CustomProperties.forEach(cp => { delete cp.Definition; });
+            }
+
+            console.log("(API Approach) Final Prepared Spira Update Payload:", JSON.stringify(updatePayload, null, 2));
+            const updateUrl = `projects/${projectId}/requirements`; 
+
+            spiraAppManager.executeApi("ConfluenceSpiraApp_UpdateReq", "7.0", "PUT", updateUrl, JSON.stringify(updatePayload),
+                function(updateResponse) { 
+                    console.log("(API Approach) Spira Req custom field update API successful. Response:", updateResponse); 
+                    spiraAppManager.displaySuccessMessage("(API Approach) Confluence page created and Spira link successfully updated!");
+                    
+                    console.log("(API Approach) Reloading Spira form...");
+                    spiraAppManager.reloadForm(); 
+
+                    if (newPageUrl) {
+                        console.log("(API Approach) Opening Confluence page (Spira PUT success):", newPageUrl);
+                        setTimeout(() => { window.open(newPageUrl, '_blank'); }, 250);
+                    }
+                },
+                function(spiraUpdateErrorStatus, spiraUpdateErrorThrown) { 
+                    console.error("(API Approach) Error updating Spira Req via API:", spiraUpdateErrorStatus, spiraUpdateErrorThrown);
+                    let errorDetail = "..."; // Simplified
+                    spiraAppManager.displayWarningMessage(`(API Approach) Confluence page created. Failed to update Spira link. Error: ${errorDetail}. Please update manually: ${newPageUrl}`);
+                    if (newPageUrl) { window.open(newPageUrl, '_blank'); }
+                }
+            );
+        },
+        function(getReqErrorStatus, getReqErrorThrown) { 
+            console.error("(API Approach) Error GETting Spira Req before update:", getReqErrorStatus, getReqErrorThrown);
+            let errorDetail = "..."; // Simplified
+            spiraAppManager.displayWarningMessage(`(API Approach) Confluence page created. Couldn't get Spira data to update. Error: ${errorDetail}. Link manually: ${newPageUrl}`);
+            if (newPageUrl) { window.open(newPageUrl, '_blank'); }
+        }
+    );
+}
+*/

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -17,11 +17,26 @@ version: 0.1 # <-- Incremented version again
 settings:
   - settingTypeId: 1 # Plain text
     name: confluenceBaseUrl
-    caption: Confluence Base URL (Optional) # Max 50 chars!
+    caption: Confluence Base URL
     isSecure: false
     placeholder: https://your-instance.atlassian.net
     position: 1
-    tooltip: The base URL of your Confluence instance (e.g., https://yourname.atlassian.net). This is combined with the 'Create Page Path'.
+    tooltip: The base URL for Confluence API calls (e.g., https://yourname.atlassian.net). Required.
+  - settingTypeId: 1 # Plain text
+    name: confluenceApiEmail
+    caption: Confluence API Email (for Basic Auth)
+    isSecure: false
+    placeholder: your.email@example.com
+    position: 2
+    tooltip: If Confluence needs Basic Auth (email:token), enter the email associated with the API Token here. Check Confluence API docs.
+  - settingTypeId: 1 # Plain text
+    name: confluenceApiToken
+    caption: Confluence API Token / Password
+    isSecure: true
+    placeholder: Enter Confluence API Token
+    position: 3
+    tooltip: The Confluence API Token. Used as password for Basic Auth or as a Bearer token. Stored securely.
+
 
 # Product-specific settings, configured per-product in Spira
 productSettings:


### PR DESCRIPTION
The intention here was to take a very basic integration (previous version) and automate more on behalf of the user. 

As such, functions to automatically create a confluence page, and then automatically open - on the edit interface - the created page on behalf of the user, while also pre-populating said confluence page with a back-link to Spira were implemented. 

It is not fully automated - the user still has to click on the "Confluence Link" field (or equivalent), in order to trigger the Spira Requirement page's dirty state, and enable the Save button, and they also have to click the save button. However, this is far more automated than merely linking an existing page which was the prior state of our functionality with this SpiraApp. 

there is scope for improvement: 
1. If we can, in a valid way, make a persistent change to the Requirement with the Confluence link value, it would be preferable
2. There is a whole world of link-back behaviour from the Confluence side which has yet to be explored - probably with a custom Confluence plug-in. 